### PR TITLE
Add a format filter to simplify debugging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,9 +9,10 @@ Installation
 
 1. In your `settings.py`, add `pdfutils` to your `INSTALLED_APPS`.
 2. `(r'^reports/', include(pdfutils.site.urls)),` to your `urls.py`
-3. Create a `report.py` file in any installed django application.
-4. Create your report(s)
-5. Profit!
+3. Add `pdfutils.autodiscover()` to your `urls.py`
+4. Create a `report.py` file in any installed django application.
+5. Create your report(s)
+6. Profit!
 
 **Note**: If you are using buildout, don't forget to put `pdfutils` 
 in your `eggs` section or else the django-pdfutils dependencies wont

--- a/pdfutils/reports.py
+++ b/pdfutils/reports.py
@@ -14,12 +14,12 @@ from django.conf import settings
 from django.contrib.staticfiles import finders
 from django.http import HttpResponse
 from django.shortcuts import render_to_response
-from django.views.generic import View
+from django.views.generic import TemplateView
 
 from pdfutils.utils import memoize, generate_pdf
 
 
-class ReportBase(View):
+class ReportBase(TemplateView):
     title = u'Untitled report'
     orientation = 'portrait'
     context = {}
@@ -27,6 +27,9 @@ class ReportBase(View):
 
     def filename(self):
         return 'Untitled-document.pdf'
+
+    def get_format(self):
+        return self.request.GET.get('format', 'pdf')
 
     @memoize
     def get_context_data(self):
@@ -90,8 +93,10 @@ class ReportBase(View):
 
         return self.response
 
-    def get(self, request):
-        return self.render()
+    def get(self, request, *args, **kwargs):
+        if self.get_format() == 'pdf':
+            return self.render()
+        return super(ReportBase, self).get(request, *args, **kwargs)
 
 
 class Report(ReportBase):


### PR DESCRIPTION
Instead of `reports/users-report/` that generate a pdf file, use `reports/users-report/?format=html` to get an html output and easily design and debug (and easier to compute for our local machine)

Cheers