### PR TITLE
Fix resource remote urls

### DIFF
--- a/pdfutils/utils.py
+++ b/pdfutils/utils.py
@@ -41,8 +41,11 @@ def fetch_resources(uri, rel):
     Callback to allow xhtml2pdf/reportlab to retrieve Images,Stylesheets, etc.
     `uri` is the href attribute from the html link element.
     `rel` gives a relative path, but it's not used here.
-
+    
     """
+    if uri.startswith('http://') or uri.startswith('https://'):
+        return uri
+        
     if uri.startswith(settings.MEDIA_URL):
         path = os.path.join(settings.MEDIA_ROOT,
                             uri.replace(settings.MEDIA_URL, ""))


### PR DESCRIPTION
Let pisa handle remote resources by avoiding the reformatting of the `uri` if it starts with `http://` or `https://`

Cheers