### PR TITLE
Letting base manage styles

### DIFF
--- a/pdfutils/reports.py
+++ b/pdfutils/reports.py
@@ -22,10 +22,9 @@ from pdfutils.utils import generate_pdf, unique
 class ReportBase(TemplateView):
     title = u'Untitled report'
     orientation = 'portrait'
-    styles = []
 
     def __init__(self):
-        self.styles = ['pdfutils/css/base.css']
+        self.__styles = ['pdfutils/css/base.css']
 
     def filename(self):
         return 'Untitled-document.pdf'
@@ -44,14 +43,20 @@ class ReportBase(TemplateView):
             'STYLES': self.render_styles(),
         }
         return self.context
+        
+    def append_styles(self, styles):
+        self.__styles = []
+        
+        for style in styles:
+            self.__styles.append(style)
 
     def get_styles(self):
         if self.orientation == 'portrait':
-            self.styles.append('pdfutils/css/portrait.css')
+            self.__styles.append('pdfutils/css/portrait.css')
         else:
-            self.styles.append('pdfutils/css/landscape.css')
-        self.styles = unique(self.styles)
-        return self.styles
+            self.__styles.append('pdfutils/css/landscape.css')
+        self.__styles = unique(self.__styles)
+        return self.__styles
 
     def render_styles(self):
         """


### PR DESCRIPTION
Mangling self.styles to self.__styles should let classes subclassing ReportBase know that you shouldn't add to styles directly and let the base class manage them.

The reason in this case is to let ReportBase handle the styles and work around the threadlock issues by cleaning the styles prior to a new report being executed. Doing so has the effect of minimizing work in the utils.unique method making sure that before each report execution we have a minimum or more explicitely the relevant styles for our current report.

Classes subclassing ReportBase should use the append_styles(self, styles) method instead of appending to styles directly.