### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'html5lib==0.90',
         'httplib2==0.9',
         'pyPdf==1.13',
-        'xhtml2pdf==0.0.4',
+        'xhtml2pdf==0.0.6',
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
Bring xhtml2pdf to the current 0.0.6 version. 

It is compatible with the project and it solves issues when generating reports with large amount of rows that caused "Division by zero" errors caused by the CSS even though the css was valid. 

See for reference on the error:
https://github.com/chrisglass/xhtml2pdf/issues/20

I have had to revisit my css as the structure of the generation is slightly different, but not much work required.