### PR TITLE
Better practice in utils.py

### DIFF
--- a/pdfutils/utils.py
+++ b/pdfutils/utils.py
@@ -58,9 +58,10 @@ def generate_pdf_template_object(template_object, file_object, context):
     Inner function to pass template objects directly instead of passing a filename
     """
     html = template_object.render(Context(context))
-    pisa.CreatePDF(html.encode("UTF-8"), file_object , encoding='UTF-8',
-                   link_callback=fetch_resources)
-    return file_object
+    pisaStatus = pisa.CreatePDF(html.encode("UTF-8"), file_object , encoding='UTF-8')
+    file_object.close()
+    return pisaStatus.err
+    
 
 
 def generate_pdf(template_name, file_object=None, context=None): # pragma: no cover
@@ -76,5 +77,6 @@ def generate_pdf(template_name, file_object=None, context=None): # pragma: no co
     if not context:
         context = {}
     tmpl = get_template(template_name)
-    generate_pdf_template_object(tmpl, file_object, context)
-    return file_object
+    pisaStatus = generate_pdf_template_object(tmpl, file_object, context)
+    file_object.close()
+    return pisaStatus


### PR DESCRIPTION
The link_callback wasn't really used...although it didn't cause harm either.

generate_pdf and generate_pdf_template_object didn't return anything useful and whatever they returned wasn't used anyways. Pisa documentation recommends that such functions/methods return the generation errors for exception catching. Not implemented here, but just an overall better practice.

Also is the addition of file_object.close(). You should manually close your StringIO objects as in some reported errors not closing them was the cause for massive slowdowns and hungry ressource usage by xhtml2pdf.

All the recommended changes here are optional, but the StringIO manual close is recommended very highly to Pisa/xhtml2pdf users.